### PR TITLE
Feature/search modules by name #PR2

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+BASE_PATH = http://localhost:8000/api/v1
+NEXT_PUBLIC_BASE_PATH = http://localhost:8000/api/v1

--- a/src/app/(main)/module/architecture/application/useCases.ts
+++ b/src/app/(main)/module/architecture/application/useCases.ts
@@ -13,4 +13,9 @@ export class UseCasesModule {
     const messageResponse = await this.repository.create(moduleData)
     return messageResponse;
   }
+
+  async searchModules (moduleName:string): Promise<ResponseRequest<ModuleEntity[]>> {
+    const messageResponse = await this.repository.search(moduleName)
+    return messageResponse;
+  }
 }

--- a/src/app/(main)/module/architecture/application/useCases.ts
+++ b/src/app/(main)/module/architecture/application/useCases.ts
@@ -1,3 +1,4 @@
+import { ResponseRequest } from '../../../../../utils/resonseRequestObj';
 import { ModuleEntity } from '../domain/entity';
 import { RepositoryModuleImpl } from '../infrastructure/repositoryImpl';
 
@@ -8,7 +9,7 @@ export class UseCasesModule {
     this.repository = repositoryImpl;
   }
 
-  async createModule(moduleData: ModuleEntity): Promise<string> {
+  async createModule(moduleData: ModuleEntity): Promise<ResponseRequest> {
     const messageResponse = await this.repository.create(moduleData)
     return messageResponse;
   }

--- a/src/app/(main)/module/architecture/application/useCases.ts
+++ b/src/app/(main)/module/architecture/application/useCases.ts
@@ -1,0 +1,15 @@
+import { ModuleEntity } from '../domain/entity';
+import { RepositoryModuleImpl } from '../infrastructure/repositoryImpl';
+
+export class UseCasesModule {
+  repository: RepositoryModuleImpl;
+
+  constructor(repositoryImpl: RepositoryModuleImpl) {
+    this.repository = repositoryImpl;
+  }
+
+  async createModule(moduleData: ModuleEntity): Promise<string> {
+    const messageResponse = await this.repository.create(moduleData)
+    return messageResponse;
+  }
+}

--- a/src/app/(main)/module/architecture/domain/entity.ts
+++ b/src/app/(main)/module/architecture/domain/entity.ts
@@ -1,18 +1,3 @@
-// export class ModuleEntity {
-//   id?: string;
-//   name: string;
-//   description: string;
-//   moduleStartDate: string;
-
-//   constructor({ id, name, description, moduleStartDate }: { id?: any, name: any, description: any, moduleStartDate: any }) {
-//     this.id = id
-//     this.name = name
-//     this.description = description
-//     this.moduleStartDate = moduleStartDate
-//   }
-// }
-
-
 export interface ModuleEntity {
   id?: string;
   name: string;

--- a/src/app/(main)/module/architecture/domain/entity.ts
+++ b/src/app/(main)/module/architecture/domain/entity.ts
@@ -1,0 +1,21 @@
+// export class ModuleEntity {
+//   id?: string;
+//   name: string;
+//   description: string;
+//   moduleStartDate: string;
+
+//   constructor({ id, name, description, moduleStartDate }: { id?: any, name: any, description: any, moduleStartDate: any }) {
+//     this.id = id
+//     this.name = name
+//     this.description = description
+//     this.moduleStartDate = moduleStartDate
+//   }
+// }
+
+
+export interface ModuleEntity {
+  id?: string;
+  name: string;
+  description: string;
+  moduleStartDate: string;
+}

--- a/src/app/(main)/module/architecture/domain/repository.ts
+++ b/src/app/(main)/module/architecture/domain/repository.ts
@@ -1,3 +1,5 @@
-export class BaseRepositoryModule {
+import { ModuleEntity } from "./entity";
 
+export interface BaseRepositoryModule {
+  create(bodyData: ModuleEntity): Promise<string>;
 }

--- a/src/app/(main)/module/architecture/domain/repository.ts
+++ b/src/app/(main)/module/architecture/domain/repository.ts
@@ -3,4 +3,6 @@ import { ModuleEntity } from "./entity";
 
 export interface BaseRepositoryModule {
   create(bodyData: ModuleEntity): Promise<ResponseRequest>;
+  search(bodyData: string): Promise<ResponseRequest>;
+
 }

--- a/src/app/(main)/module/architecture/domain/repository.ts
+++ b/src/app/(main)/module/architecture/domain/repository.ts
@@ -1,0 +1,3 @@
+export class BaseRepositoryModule {
+
+}

--- a/src/app/(main)/module/architecture/domain/repository.ts
+++ b/src/app/(main)/module/architecture/domain/repository.ts
@@ -1,5 +1,6 @@
+import { ResponseRequest } from "../../../../../utils/resonseRequestObj";
 import { ModuleEntity } from "./entity";
 
 export interface BaseRepositoryModule {
-  create(bodyData: ModuleEntity): Promise<string>;
+  create(bodyData: ModuleEntity): Promise<ResponseRequest>;
 }

--- a/src/app/(main)/module/architecture/infrastructure/adapters.ts
+++ b/src/app/(main)/module/architecture/infrastructure/adapters.ts
@@ -1,0 +1,13 @@
+import { ModuleEntity } from "../domain/entity"
+
+export const searchModulesAdapter = (modulesFound:Array<any>) => {
+  const listMopdulesAdapted = modulesFound.map((module) => {
+    return {
+      id:module["id"],
+      name:module["name"],
+      moduleStartDate:module["moduleStartDate"],
+      description:module["description"],
+    } as ModuleEntity
+  })
+  return listMopdulesAdapted;
+}

--- a/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
+++ b/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
@@ -1,12 +1,30 @@
 import { ModuleEntity } from "../domain/entity";
 import { BaseRepositoryModule } from "../domain/repository";
+import { ResponseRequest } from '../../../../../utils/resonseRequestObj';
 
 export class RepositoryModuleImpl implements BaseRepositoryModule {
-  async create(bodyData: ModuleEntity): Promise<string> {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH}/modules`, {
-      method: 'POST',
-      body: JSON.stringify(bodyData)
-    })
-    return JSON.stringify(res)
+  async create(bodyData: ModuleEntity): Promise<ResponseRequest> {
+    try {
+      const res = await (await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH}/modules`, {
+        method: "POST", 
+        body: JSON.stringify(bodyData), 
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })).json()
+      const data: ResponseRequest = {
+        succes:true,
+        err:false,
+        message:res,
+        data:null
+      }
+      return data;
+    } catch (error) {
+      console.log("entre");
+      let err = error as Error
+      throw new Error(err.message)
+    }
+    
+   
   }
 }

--- a/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
+++ b/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
@@ -1,5 +1,12 @@
+import { ModuleEntity } from "../domain/entity";
 import { BaseRepositoryModule } from "../domain/repository";
 
-class RepositoryModuleImpl extends BaseRepositoryModule {
-
+export class RepositoryModuleImpl implements BaseRepositoryModule {
+  async create(bodyData: ModuleEntity): Promise<string> {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH}/modules`, {
+      method: 'POST',
+      body: JSON.stringify(bodyData)
+    })
+    return JSON.stringify(res)
+  }
 }

--- a/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
+++ b/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
@@ -1,0 +1,5 @@
+import { BaseRepositoryModule } from "../domain/repository";
+
+class RepositoryModuleImpl extends BaseRepositoryModule {
+
+}

--- a/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
+++ b/src/app/(main)/module/architecture/infrastructure/repositoryImpl.ts
@@ -1,8 +1,35 @@
 import { ModuleEntity } from "../domain/entity";
 import { BaseRepositoryModule } from "../domain/repository";
 import { ResponseRequest } from '../../../../../utils/resonseRequestObj';
+import { searchModulesAdapter } from "./adapters";
+import { filterModulesByName } from "../../../../../utils/filterModules";
 
 export class RepositoryModuleImpl implements BaseRepositoryModule {
+  async search(moduleName: string): Promise<ResponseRequest> {
+    //! i need create endpoint backend to search by name
+    try {
+      const res = await (await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH}/modules`, {
+        method: "GET", 
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })).json()
+      //!this make a map to normalize the response with an adapter.
+      const adaptedListModule = searchModulesAdapter(res)
+      
+      const data: ResponseRequest = {
+        succes:true,
+        err:false,
+        message:"",
+        data:filterModulesByName(adaptedListModule,moduleName) //!this filter modules by name , i think we could make this in backend
+      }
+      return data;
+    } catch (error) {
+      let err = error as Error
+      throw new Error(err.message)
+    }
+  }
+
   async create(bodyData: ModuleEntity): Promise<ResponseRequest> {
     try {
       const res = await (await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH}/modules`, {
@@ -24,7 +51,5 @@ export class RepositoryModuleImpl implements BaseRepositoryModule {
       let err = error as Error
       throw new Error(err.message)
     }
-    
-   
   }
 }

--- a/src/app/(main)/module/architecture/interactionHook/useCasesHook.tsx
+++ b/src/app/(main)/module/architecture/interactionHook/useCasesHook.tsx
@@ -1,6 +1,10 @@
+import { useMemo, useRef } from 'react';
 import { UseCasesModule } from '../application/useCases';
 import { RepositoryModuleImpl } from '../infrastructure/repositoryImpl';
 
 export const useCasesHook = () => {
-    return new UseCasesModule(new RepositoryModuleImpl());
+    const repositoryModuleImpl = new RepositoryModuleImpl();
+    const cases = useRef(new UseCasesModule(repositoryModuleImpl));
+
+    return cases.current;
 };

--- a/src/app/(main)/module/architecture/interactionHook/useCasesHook.tsx
+++ b/src/app/(main)/module/architecture/interactionHook/useCasesHook.tsx
@@ -1,0 +1,6 @@
+import { UseCasesModule } from '../application/useCases';
+import { RepositoryModuleImpl } from '../infrastructure/repositoryImpl';
+
+export const useCasesHook = () => {
+    return new UseCasesModule(new RepositoryModuleImpl());
+};

--- a/src/app/(main)/module/components/DateInitial.tsx
+++ b/src/app/(main)/module/components/DateInitial.tsx
@@ -8,7 +8,7 @@ export default function DateInitial() {
     return (
         <div className="w-full gap-2 flex flex-column justify-content-center align-content-center">
             <label className="text-600 text-sm">{dictionary.InitDate}</label>
-            <Calendar name="date" placeholder={dictionary.DateFormat} showIcon className="border-round-xl border-none bg-bluegray-900" />
+            <Calendar required name="date" placeholder={dictionary.DateFormat} showIcon className="border-round-xl border-none bg-bluegray-900" />
         </div>
     );
 }

--- a/src/app/(main)/module/components/DateInitial.tsx
+++ b/src/app/(main)/module/components/DateInitial.tsx
@@ -3,13 +3,12 @@ import { Calendar } from 'primereact/calendar';
 import { useAppSelector } from '../../../../redux/hooks/hooks';
 //!esto tenemos que hacerlo general <<< sacar de aqui, el calendario se puede usar en otras features
 export default function DateInitial() {
-    const [date, setDate] = useState(null);
     const dictionary = useAppSelector((state) => state.reducerLanguage).dictionary;
 
     return (
         <div className="w-full gap-2 flex flex-column justify-content-center align-content-center">
             <label className="text-600 text-sm">{dictionary.InitDate}</label>
-            <Calendar value={date} placeholder={dictionary.DateFormat} onChange={(e) => setDate(e.value)} showIcon className="border-round-xl border-none bg-bluegray-900" />
+            <Calendar name="date" placeholder={dictionary.DateFormat} showIcon className="border-round-xl border-none bg-bluegray-900" />
         </div>
     );
 }

--- a/src/app/(main)/module/components/SearchModule.tsx
+++ b/src/app/(main)/module/components/SearchModule.tsx
@@ -1,15 +1,36 @@
-import React from 'react';
+import { useState } from 'react';
 import { InputText } from 'primereact/inputtext';
 import { useAppSelector } from '../../../../redux/hooks/hooks';
+import { useCasesHook } from '../architecture/interactionHook/useCasesHook';
+import { ModuleEntity } from '../architecture/domain/entity';
 
-export default function SearchModule() {
+interface Props {
+    getModulesSearched: (modules:ModuleEntity[]) => void
+}
+
+export default function SearchModule({getModulesSearched}:Props) {
+    const cases = useCasesHook();
+    const [value,setValue] =  useState<string>();
     const dictionary = useAppSelector((state) => state.reducerLanguage).dictionary;
+    const [err, setErr] = useState({
+        status:false,
+        msg:""
+    });
+    //!Error hanlder is missing here, i need creat a catched global error component with a class
+    const moduleSearchHandler = async () => {
+        if(!value) return 
+        const response = await cases.searchModules(value).catch((err:Error) => setErr({
+            msg:err.message,
+            status:true
+        }));
+        response && getModulesSearched(response.data)
+    }
 
     return (
         <div className="w-full max-h-3rem flex justify-content-center ">
             <span className="w-full p-input-icon-left align-items-center justify-content-center">
-                <i className="pi pi-search text-white text-xl " />
-                <InputText placeholder={dictionary.SearchModule} className="border-none w-full max-h-full bg-bluegray-900 border-round-3xl" />
+                <i onClick={moduleSearchHandler} className="pi pi-search text-white text-xl cursor-pointer" />
+                <InputText onChange={evt => setValue(evt.target.value)} placeholder={dictionary.SearchModule} className="border-none w-full max-h-full bg-bluegray-900 border-round-3xl" />
             </span>
         </div>
     );

--- a/src/app/(main)/module/create/page.tsx
+++ b/src/app/(main)/module/create/page.tsx
@@ -41,7 +41,7 @@ const CreateModule = () => {
                 </div>
                 <div className="flex w-full flex-column gap-2 ">
                     <label className="text-600 text-sm">{dictionary.Description}</label>
-                    <InputTextarea name="description" placeholder={dictionary.ObjectiveOfTheModule} rows={5} cols={30} className="max-w-full border-round-xl border-none bg-bluegray-900" />
+                    <InputTextarea required name="description" placeholder={dictionary.ObjectiveOfTheModule} rows={5} cols={30} className="max-w-full border-round-xl border-none bg-bluegray-900" />
                 </div>
                 <div className="flex justify-content-between align-items-center">
                     <SearchModule />

--- a/src/app/(main)/module/create/page.tsx
+++ b/src/app/(main)/module/create/page.tsx
@@ -6,26 +6,34 @@ import DateInitial from '../components/DateInitial';
 import { InputTextarea } from 'primereact/inputtextarea';
 import SearchModule from '../components/SearchModule';
 import { Button } from 'primereact/button';
-import { FormEvent } from 'react';
+import { FormEvent, useState } from 'react';
 import { useCasesHook } from '../architecture/interactionHook/useCasesHook';
 import { ModuleEntity } from '../architecture/domain/entity';
 
 const CreateModule = () => {
     const cases = useCasesHook();
+    const [err, setErr] = useState({
+        status:false,
+        msg:""
+    });
     const dictionary = useAppSelector((state) => state.reducerLanguage).dictionary;
 
     const createModuleHandler = async (evt: FormEvent<HTMLFormElement>) => {
         evt.preventDefault();
         const dataFromForm = Object.fromEntries(new FormData(evt.target as HTMLFormElement));
         const bodyData: ModuleEntity = { name: String(dataFromForm['name']), description: String(dataFromForm['name']), moduleStartDate: String(dataFromForm['date']) };
-        const response = await cases.createModule(bodyData);
-        console.log(response);
+        await cases.createModule(bodyData).catch((err:Error) => {
+            setErr({
+                status:true,
+                msg:err.message
+            })
+        });
     };
-    console.log(process.env.NEXT_PUBLIC_BASE_PATH);
 
     return (
         <div className="w-10 flex flex-column justify-content-center align-items-center my-0 mx-auto gap-5">
             <form className="mt-6 flex flex-column w-8 gap-3" onSubmit={createModuleHandler}>
+                {err.status ? <p>{err.msg}</p>:<></>}
                 <h4>{dictionary.CreateModule}</h4>
                 <div className="w-full gap-3 flex flex-row gap  justify-start justify-items-center">
                     <InputPrimary size="large" title={dictionary.NameOfModule} placeHolder={dictionary.PholderNameModule} />

--- a/src/app/(main)/module/create/page.tsx
+++ b/src/app/(main)/module/create/page.tsx
@@ -1,21 +1,31 @@
 'use client';
-import FormCreateModule from '../components/FormCreateModule';
 import DataTableModules from '../components/DataTableModules';
-import { useParams, usePathname, useRouter, } from 'next/navigation';
 import { useAppSelector } from '../../../../redux/hooks/hooks';
 import { InputPrimary } from '../../../../components/InputPrimary/InputPrimary';
 import DateInitial from '../components/DateInitial';
 import { InputTextarea } from 'primereact/inputtextarea';
 import SearchModule from '../components/SearchModule';
 import { Button } from 'primereact/button';
-
+import { FormEvent } from 'react';
+import { useCasesHook } from '../architecture/interactionHook/useCasesHook';
+import { ModuleEntity } from '../architecture/domain/entity';
 
 const CreateModule = () => {
+    const cases = useCasesHook();
     const dictionary = useAppSelector((state) => state.reducerLanguage).dictionary;
-    
+
+    const createModuleHandler = async (evt: FormEvent<HTMLFormElement>) => {
+        evt.preventDefault();
+        const dataFromForm = Object.fromEntries(new FormData(evt.target as HTMLFormElement));
+        const bodyData: ModuleEntity = { name: String(dataFromForm['name']), description: String(dataFromForm['name']), moduleStartDate: String(dataFromForm['date']) };
+        const response = await cases.createModule(bodyData);
+        console.log(response);
+    };
+    console.log(process.env.NEXT_PUBLIC_BASE_PATH);
+
     return (
         <div className="w-10 flex flex-column justify-content-center align-items-center my-0 mx-auto gap-5">
-            <form className="mt-6 flex flex-column w-8 gap-3">
+            <form className="mt-6 flex flex-column w-8 gap-3" onSubmit={createModuleHandler}>
                 <h4>{dictionary.CreateModule}</h4>
                 <div className="w-full gap-3 flex flex-row gap  justify-start justify-items-center">
                     <InputPrimary size="large" title={dictionary.NameOfModule} placeHolder={dictionary.PholderNameModule} />
@@ -23,11 +33,11 @@ const CreateModule = () => {
                 </div>
                 <div className="flex w-full flex-column gap-2 ">
                     <label className="text-600 text-sm">{dictionary.Description}</label>
-                    <InputTextarea placeholder={dictionary.ObjectiveOfTheModule} rows={5} cols={30} className="max-w-full border-round-xl border-none bg-bluegray-900" />
+                    <InputTextarea name="description" placeholder={dictionary.ObjectiveOfTheModule} rows={5} cols={30} className="max-w-full border-round-xl border-none bg-bluegray-900" />
                 </div>
                 <div className="flex justify-content-between align-items-center">
                     <SearchModule />
-                    <Button label={dictionary.Create} icon="pi pi-plus" iconPos="right" className="h-full w-2 ml-6 border-round-xl p-3" />
+                    <Button type="submit" label={dictionary.Create} icon="pi pi-plus" iconPos="right" className="h-full w-2 ml-6 border-round-xl p-3" />
                 </div>
             </form>
             <DataTableModules />

--- a/src/components/InputPrimary/InputPrimary.tsx
+++ b/src/components/InputPrimary/InputPrimary.tsx
@@ -12,7 +12,7 @@ export const InputPrimary = ({ title, placeHolder }: Props) => {
     return (
         <div className="w-full flex flex-column gap-2">
             <label className="text-600 text-sm">{title}</label>
-            <InputText name="name" type="text" placeholder={placeHolder} className={`border-round-xl border-none bg-bluegray-900`} />
+            <InputText required name="name" type="text" placeholder={placeHolder} className={`border-round-xl border-none bg-bluegray-900`} />
         </div>
     );
 };

--- a/src/components/InputPrimary/InputPrimary.tsx
+++ b/src/components/InputPrimary/InputPrimary.tsx
@@ -12,7 +12,7 @@ export const InputPrimary = ({ title, placeHolder }: Props) => {
     return (
         <div className="w-full flex flex-column gap-2">
             <label className="text-600 text-sm">{title}</label>
-            <InputText type="text" placeholder={placeHolder} className={`border-round-xl border-none bg-bluegray-900`} />
+            <InputText name="name" type="text" placeholder={placeHolder} className={`border-round-xl border-none bg-bluegray-900`} />
         </div>
     );
 };

--- a/src/utils/filterModules.ts
+++ b/src/utils/filterModules.ts
@@ -1,0 +1,9 @@
+import { ModuleEntity } from "../app/(main)/module/architecture/domain/entity";
+
+export function filterModulesByName(modulesArr: ModuleEntity[], moduleName: string): ModuleEntity[] {
+  const normalizeName = moduleName.toLowerCase().trim(); 
+  
+  return modulesArr.filter(module =>
+    module.name.toLowerCase().includes(normalizeName)
+  );
+}

--- a/src/utils/resonseRequestObj.ts
+++ b/src/utils/resonseRequestObj.ts
@@ -1,0 +1,6 @@
+export interface ResponseRequest {
+  succes:boolean
+  err:boolean
+  message:string
+  data:any
+}

--- a/src/utils/resonseRequestObj.ts
+++ b/src/utils/resonseRequestObj.ts
@@ -1,6 +1,6 @@
-export interface ResponseRequest {
+export interface ResponseRequest<T = any> {
   succes:boolean
   err:boolean
   message:string
-  data:any
+  data:T
 }


### PR DESCRIPTION
Esto es para buscar el modulo, tenemos que charlar para ver que es mejor. Yo había propuesto hacerlo en backend pero también esta la posibilidad de hacerlo desde el frontend como esta implementado ahora. Lo hice así ahora por cuestiones de tiempo porque el endpoint no existe en backend.

Se pide disculpas por hacer el pull de la rama "feature/funcionalityCreateModule" #1, esto me trajo todos los commits del mismo. 

Por favor si usted ya vio el primer (PR #1), empiece viendo este PR a partir del commit #10 llamado " add generic to improve the responses when the request return something" ya que es lo nuevo que pertenece realmente a esta rama.

Según mi entendimiento del funcionamiento de la vista "edit modules", se necesita esta funcionalidad para poder seleccionar el modulo que se quiere editar, es decir, se necesita mergear esto.